### PR TITLE
Add appatlas plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -385,6 +385,31 @@
         "ssot"
       ],
       "category": "developer-tools"
+    },
+    {
+      "name": "appatlas",
+      "source": {
+        "source": "github",
+        "repo": "sleepyw33kday/appatlas"
+      },
+      "description": "Walk an entire web or mobile app end to end and produce a browsable atlas of every screen: screenshots, per-screen behavior specs, a faceted tag index, and a flow graph linking screens by what opens what.",
+      "version": "1.0.0",
+      "author": {
+        "name": "sleepyw33kday"
+      },
+      "repository": "https://github.com/sleepyw33kday/appatlas",
+      "license": "MIT",
+      "keywords": [
+        "app-walkthrough",
+        "teardown",
+        "ux-research",
+        "screenshots",
+        "browser-automation",
+        "documentation",
+        "ios",
+        "android"
+      ],
+      "category": "developer-tools"
     }
   ]
 }


### PR DESCRIPTION
Adds **appatlas** to the marketplace.

AppAtlas is a Claude Code skill and plugin that walks an entire web or mobile app end to end and produces a browsable atlas of every screen: screenshots, per-screen behavior specs, a faceted (Mobbin-style) tag index, and a flow graph that links screens by what opens what. Works on web via the Claude-in-Chrome tools and on iOS/Android via the simulator/emulator.

- Repo: https://github.com/sleepyw33kday/appatlas (MIT)
- Live example atlas (350 real screens): https://sleepyw33kday.github.io/appatlas/example/
- The repo is itself a valid `.claude-plugin` marketplace + plugin.

Entry follows the existing schema (name / source / description / version / author / repository / license / keywords / category = developer-tools). Single new entry appended; no existing entries changed.